### PR TITLE
Enable installations on Apple Silicon

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -5,6 +5,8 @@ set \
   -o nounset \
   -o pipefail
 
+source "$(dirname $0)/../lib/utils.sh"
+
 # required environment variables
 : ${ASDF_INSTALL_VERSION?}
 : ${ASDF_DOWNLOAD_PATH?}
@@ -34,25 +36,6 @@ download() {
     echo "Failed to download ${filename}"
     exit 1
   fi
-}
-
-# get the OS family name
-get_os() {
-  uname | tr '[:upper:]' '[:lower:]'
-}
-
-# get the cpu architecture
-get_arch() {
-  local -r arch=$(uname -m)
-  
-  case $arch in
-    x86_64)
-      echo amd64
-      ;;
-    *86)
-      echo 386
-      ;;
-  esac
 }
 
 # return the full URL to the download

--- a/bin/install
+++ b/bin/install
@@ -5,6 +5,8 @@ set \
   -o nounset \
   -o pipefail
 
+source "$(dirname $0)/../lib/utils.sh"
+
 # required environment variables
 : ${ASDF_INSTALL_TYPE?}
 : ${ASDF_INSTALL_VERSION?}
@@ -31,23 +33,6 @@ install() {
       echo "Failed to install ${toolname} ${ASDF_INSTALL_VERSION}"
       exit 1
     fi
-}
-
-get_os() {
-  uname | tr '[:upper:]' '[:lower:]'
-}
-
-get_arch() {
-  local -r arch=$(uname -m)
-
-  case $arch in
-    x86_64)
-      echo amd64
-      ;;
-    *86)
-      echo 386
-      ;;
-  esac
 }
 
 install

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,18 @@
+# get the OS family name
+get_os() {
+  uname | tr '[:upper:]' '[:lower:]'
+}
+
+# get the cpu architecture
+get_arch() {
+  local -r arch=$(uname -m)
+
+  case $arch in
+    x86_64)
+      echo amd64
+      ;;
+    *86)
+      echo 386
+      ;;
+  esac
+}

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -14,5 +14,9 @@ get_arch() {
     *86)
       echo 386
       ;;
+    *)
+      # e.g. "arm64"
+      echo $arch
+      ;;
   esac
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -8,7 +8,7 @@ get_arch() {
   local -r arch=$(uname -m)
 
   case $arch in
-    x86_64)
+    arm64|x86_64)
       echo amd64
       ;;
     *86)


### PR DESCRIPTION
`darwin-arm64` builds aren't currently produced by `task`, but I've raised go-task/task#567 to fix that. In the meantime, we can rely on Rosetta 2 with the existing `amd64` binaries :+1: