### PR TITLE
Revert "Use amd64 builds on Apple Silicon"

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -8,7 +8,7 @@ get_arch() {
   local -r arch=$(uname -m)
 
   case $arch in
-    arm64|x86_64)
+    x86_64)
       echo amd64
       ;;
     *86)


### PR DESCRIPTION
Task now releases darwin-arm64 builds as of 3.7.3 🎉

This reverts commit 4684aaf17b41d8b554d7d30563310883e941a0ab.