### PR TITLE
Download arm64 build when uname -m returns aarch64

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -14,6 +14,9 @@ get_arch() {
     *86)
       echo 386
       ;;
+    aarch64)
+      echo arm64
+      ;;
     *)
       # e.g. "arm64"
       echo $arch


### PR DESCRIPTION
Some systems return `aarch64` instead of `arm64` for `uname -m` this downloads the right binary for those

<img width="977" alt="image" src="https://user-images.githubusercontent.com/21379/180005375-605dd709-9f9b-4b6e-8e3c-903162fc6a0d.png">
